### PR TITLE
改进 B 站弹幕连接和礼物数据处理的健壮性与用户反馈

### DIFF
--- a/main.py
+++ b/main.py
@@ -1567,7 +1567,7 @@ async def check_b_connect_status():
     switch_value = b_connect_switch.value
 
     def disconnect_timer():
-        if switch_value == "null":
+        if b_connect_switch.value == "null":
             ui.notify("连接超时，请检查日志", type="negative")
             b_connect_switch.set_value(False)
 
@@ -1739,7 +1739,7 @@ async def refresh_gift(heartbeat=False):
             await create_blind_box()
         except Exception as e:
             logger.error(f"更新礼物数据时发生错误: {e}")
-            raise e
+            raise
 
         if gift_config == True:
             ui.notify("礼物数据更新完成", type="positive")

--- a/main.py
+++ b/main.py
@@ -38,6 +38,7 @@ from blivedm import blivedm
 # Third Party Packages
 import os
 import re
+import time
 import orjson
 import shutil
 import random
@@ -1565,6 +1566,11 @@ async def check_b_connect_status():
     global b_connect_status
     switch_value = b_connect_switch.value
 
+    def disconnect_timer():
+        if switch_value == "null":
+            ui.notify("连接超时，请检查日志", type="negative")
+            b_connect_switch.set_value(False)
+
     # 开关关闭状态：断开连接
     if switch_value == False:
         # 无身份码且未连接
@@ -1578,7 +1584,7 @@ async def check_b_connect_status():
         b_connect_status = False
         client.stop() # 断开弹幕服务器ws连接
         logger.info("弹幕服务器ws连接已断开")
-        ui.notify("已断开连接，这通常是因为手动关闭了连接或身份码不正确")
+        ui.notify("已断开连接")
         b_connect_switch.set_value(False)
         b_connect_switch.set_text("连接至弹幕服务器")
         login_status.set_text("未连接")
@@ -1595,6 +1601,7 @@ async def check_b_connect_status():
         # 启动连接
         if not b_connect_status:
             asyncio.create_task(start_handler())
+            ui.timer(30, lambda: disconnect_timer(), once=True) # 如果超时仍未连接强制断开
             b_connect_switch.set_value("null")
             b_connect_switch.set_text("尝试连接弹幕服务器")
             login_status.set_text("未连接")

--- a/main.py
+++ b/main.py
@@ -383,6 +383,8 @@ class BiliHandler(blivedm.BaseHandler):
     heart_count = 0
     # 心跳数据
     async def _on_heartbeat(self, client: blivedm.BLiveClient, message: web_models.HeartbeatMessage):
+        global b_connect_status
+
         self.heart_count += 1
         logger.info("触发心跳")
         if self.heart_count == 1:
@@ -400,10 +402,12 @@ class BiliHandler(blivedm.BaseHandler):
             with main_card:
                 ui.notify("正在等待B站下发自定义礼物数据，请稍候...", type="info")
                 await asyncio.sleep(5) # 等待5秒B站发送自定义礼物数据
-                await refresh_gift(True) # 刷新礼物数据
 
-            b_connect_switch.set_value(True)
-            b_connect_switch.set_text("已连接弹幕服务器")
+                try:
+                    await refresh_gift(True) # 刷新礼物数据
+                except:
+                    ui.notify("获取礼物数据失败，可能导致部分功能异常", type="warning")
+
             logger.info(f"已连接至{room_id}")
 
             uid = client.room_owner_uid
@@ -412,6 +416,9 @@ class BiliHandler(blivedm.BaseHandler):
                 await travail_stat.stat(room_id, uid, version, now_time)
                 login_status.set_text(room_id)
                 login_status.classes("text-green")
+                b_connect_status = True # 在第一次心跳时设置状态为已连接至弹幕服务器
+                b_connect_switch.set_value(True)
+                b_connect_switch.set_text("已连接弹幕服务器")
             else:
                 login_status.set_text("未连接")
                 login_status.classes(replace="text-red")
@@ -1592,7 +1599,6 @@ async def check_b_connect_status():
             b_connect_switch.set_text("尝试连接弹幕服务器")
             login_status.set_text("未连接")
             login_status.classes(replace="text-red")
-            b_connect_status = True
         else:
             b_connect_switch.set_value(True)
 
@@ -1721,8 +1727,12 @@ async def refresh_gift(heartbeat=False):
 
         await asyncio.sleep(1)
 
-        gift_config = await GiftManager.get_config("data/gift_img.json")
-        await create_blind_box()
+        try:
+            gift_config = await GiftManager.get_config("data/gift_img.json")
+            await create_blind_box()
+        except Exception as e:
+            logger.error(f"更新礼物数据时发生错误: {e}")
+            raise e
 
         if gift_config == True:
             ui.notify("礼物数据更新完成", type="positive")
@@ -1746,7 +1756,7 @@ async def refresh_gift(heartbeat=False):
             await GiftManager.init_gift("data/gift_img.json")
             ui.notify("重置成功", type="positive")
         except Exception as e:
-            logger.exception(f"使用本地数据重置失败：{e}")
+            logger.error(f"使用本地数据重置失败：{e}")
             ui.notify("重置失败", type="negative")
 
     if heartbeat:
@@ -2691,9 +2701,9 @@ async def _():
             except asyncio.TimeoutError:
                 logger.warning(f"请求超时: {url}")
             except aiohttp.ClientError as e:
-                logger.exception(f"网络错误: {url} - {e}")
+                logger.error(f"网络错误: {url} - {e}")
             except Exception as e:
-                logger.exception(f"未知错误: {url} - {e}")
+                logger.error(f"未知错误: {url} - {e}")
             return None
 
         async def get_remote_text(session):
@@ -2753,7 +2763,7 @@ async def _():
                     )
 
             except Exception as e:
-                logger.exception(f"显示聊天消息失败: {e}")
+                logger.error(f"显示聊天消息失败: {e}")
                 # 显示错误消息
                 ui.notify("加载聊天消息失败，请稍后再试", type="negative")
 


### PR DESCRIPTION
## 由 Sourcery 总结

改进 B 站弹幕连接和礼物数据处理的健壮性与用户反馈。

Bug 修复：
- 确保弹幕连接状态标志只在首次心跳成功后才设置为已连接。
- 增加超时机制，当弹幕服务器连接在限定时间内未成功时，会自动取消正在进行的连接尝试并通知用户。
- 处理刷新或更新礼物数据时的失败情况，将错误记录到日志并向用户展示，而不是静默失败。

增强项：
- 优化连接与断开连接的通知，使其更准确地反映弹幕服务器连接的实际状态。
- 将部分异常日志降级为错误日志，以减少冗长的堆栈信息，同时仍能捕获失败情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve robustness and user feedback around Bilibili danmaku connection and gift data handling.

Bug Fixes:
- Ensure the danmaku connection status flag is only set to connected after the first successful heartbeat.
- Add a timeout mechanism that automatically cancels an in-progress connection attempt and notifies the user if the danmaku server connection does not succeed in time.
- Handle failures when refreshing or updating gift data so that errors are logged and surfaced to the user instead of silently failing.

Enhancements:
- Refine connection and disconnection notifications to better reflect the actual status of the danmaku server connection.
- Downgrade several exception logs to error logs to reduce noisy stack traces while still capturing failures.

</details>